### PR TITLE
Running instance type metric

### DIFF
--- a/src/main/java/org/jmal98/ec2/collectors/InstanceType.java
+++ b/src/main/java/org/jmal98/ec2/collectors/InstanceType.java
@@ -27,8 +27,8 @@ public class InstanceType extends Collector {
         }
 
         GaugeMetricFamily labeledGauge = new GaugeMetricFamily(
-                "ec2_instances",
-                "Instance details by state",
+                "ec2_instances_by_type",
+                "Instance details by type",
                 Collections.singletonList("state")
             );
         for (String name : instancesByType.keySet()) {

--- a/src/main/java/org/jmal98/ec2/collectors/InstanceType.java
+++ b/src/main/java/org/jmal98/ec2/collectors/InstanceType.java
@@ -1,0 +1,78 @@
+package org.jmal98.ec2.collectors;
+
+import com.amazonaws.services.ec2.AmazonEC2;
+import com.amazonaws.services.ec2.model.*;
+import io.prometheus.client.Collector;
+import io.prometheus.client.GaugeMetricFamily;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.*;
+
+public class InstanceType extends Collector {
+
+	private final Logger logger = LogManager.getLogger(getClass());
+
+	@Override
+	public List<MetricFamilySamples> collect() {
+		List<MetricFamilySamples> mfs = new ArrayList<>();
+
+		Map<String, Integer> instancesByType = new HashMap<>();
+
+		AmazonEC2 ec2 = AmazonEc2ClientCache.getClient();
+
+        String nextToken = null;
+        while ((nextToken = list(ec2, instancesByType, nextToken)) != null) {
+            logger.warn("Iterating to obtain more information");
+        }
+
+        GaugeMetricFamily labeledGauge = new GaugeMetricFamily(
+                "ec2_instances",
+                "Instance details by state",
+                Collections.singletonList("state")
+            );
+        for (String name : instancesByType.keySet()) {
+            Integer total = instancesByType.get(name);
+
+            labeledGauge.addMetric(Collections.singletonList(name),
+                    Double.valueOf(total));
+        }
+        mfs.add(labeledGauge);
+
+        return mfs;
+	}
+
+	private static String list(AmazonEC2 ec2, Map<String, Integer> instancesByType, String nextToken) {
+		int maxResults = 250;  // a quarter of max to reduce memory usage
+        DescribeInstancesResult dir = null;
+        if (nextToken != null) {
+            dir = ec2
+                    .describeInstances(
+                            new DescribeInstancesRequest()
+                            .withMaxResults(maxResults)
+                            .withNextToken(nextToken)
+                            );
+        } else {
+            dir = ec2
+                    .describeInstances(
+                            new DescribeInstancesRequest()
+                            .withMaxResults(maxResults)
+                            );
+        }
+
+        if (dir != null) {
+
+            for (Reservation reservation : dir.getReservations()) {
+                for (Instance instance : reservation.getInstances()) {
+                    Integer cur = instancesByType.getOrDefault(instance.getInstanceType(), 0);
+                    instancesByType.put(instance.getInstanceType(), cur + 1);
+                }
+            }
+
+            return dir.getNextToken();
+        }
+        return null;
+	}
+
+
+}

--- a/src/main/java/org/jmal98/ec2/collectors/InstanceType.java
+++ b/src/main/java/org/jmal98/ec2/collectors/InstanceType.java
@@ -27,9 +27,9 @@ public class InstanceType extends Collector {
         }
 
         GaugeMetricFamily labeledGauge = new GaugeMetricFamily(
-                "ec2_instances_by_type",
-                "Instance details by type",
-                Collections.singletonList("state")
+                "ec2_instances_by_type_running",
+                "Instance details by type, filtered by running instances",
+                Collections.singletonList("type")
             );
         for (String name : instancesByType.keySet()) {
             Integer total = instancesByType.get(name);
@@ -64,6 +64,9 @@ public class InstanceType extends Collector {
 
             for (Reservation reservation : dir.getReservations()) {
                 for (Instance instance : reservation.getInstances()) {
+                    if(!instance.getState().getName().equals("running")) {
+                        continue;
+                    }
                     Integer cur = instancesByType.getOrDefault(instance.getInstanceType(), 0);
                     instancesByType.put(instance.getInstanceType(), cur + 1);
                 }

--- a/src/main/java/org/jmal98/ec2/exporter/Application.java
+++ b/src/main/java/org/jmal98/ec2/exporter/Application.java
@@ -11,6 +11,7 @@ import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.servlet.ServletHandler;
 import org.jmal98.ec2.collectors.InstanceHealth;
 import org.jmal98.ec2.collectors.InstanceState;
+import org.jmal98.ec2.collectors.InstanceType;
 import org.jmal98.ec2.collectors.Volumes;
 
 import io.prometheus.client.Counter;
@@ -38,7 +39,8 @@ public class Application {
 		new Volumes().register();
 		new InstanceState().register();
 		new InstanceHealth().register();
-		
+		new InstanceType().register();
+
 		Server server = new Server(9385);
 
 		ServletHandler handler = new ServletHandler();
@@ -51,7 +53,7 @@ public class Application {
 
 		logger.info("Exporter has started.");
 		startup.inc();
-		
+
 		HttpGenerator.setJettyVersion("");
 
 		server.join();


### PR DESCRIPTION
Adds a `ec2_instances_by_type_running` metric.

Copied a already existing metric, and modified it this way.

My use case: sending a notification when "something" started too many instances of a type.